### PR TITLE
Prevent percentage memory calculation from overflowing

### DIFF
--- a/src/limits/Misc/MemoryAvailable.cpp
+++ b/src/limits/Misc/MemoryAvailable.cpp
@@ -23,7 +23,8 @@ struct MemoryLimit : public SimpleAdjuster
             MEMORYSTATUSEX sysmem = { sizeof(sysmem) };
             if(GlobalMemoryStatusEx(&sysmem))
             {
-                memory = uint32_t(sysmem.ullTotalPhys * std::stoul(value.substr(0, value.size() - 1)) / 100);
+                auto calcmem = sysmem.ullTotalPhys * (std::stoul(value.substr(0, value.size() - 1)) / 100.0);
+                memory = calcmem > UINT32_MAX ? UINT32_MAX : uint32_t(calcmem); // use the maximum value of uint32_t (if the calculated value exceeds the capacity)
             }
         }
         else


### PR DESCRIPTION
The current implementation causes a backwards logic due to overflowing/type casting from calculated values being too big on systems with too much RAM.

I've fixed it by capping it to the max of uint32_t.

More info at: https://gtaforums.com/topic/736512-open-limit-adjuster/?do=findComment&comment=1072454536 